### PR TITLE
Intercept page content to store separately

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -33,6 +33,9 @@
 		"BeforePageDisplay": "LakatHooks",
 		"SkinTemplateNavigation::Universal": "LakatHooks"
 	},
+	"ContentHandlers": {
+		"lakat": "MediaWiki\\Extension\\Lakat\\LakatContentHandler"
+	},
 	"SpecialPages": {
 		"CreateBranch": "MediaWiki\\Extension\\Lakat\\SpecialCreateBranch"
 	},

--- a/src/LakatContent.php
+++ b/src/LakatContent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use TextContent;
+
+class LakatContent extends TextContent {
+
+	public const MODEL_ID = 'lakat';
+
+	public function __construct( $text ) {
+		parent::__construct( $text, self::MODEL_ID );
+	}
+}

--- a/src/LakatContentHandler.php
+++ b/src/LakatContentHandler.php
@@ -2,9 +2,6 @@
 
 namespace MediaWiki\Extension\Lakat;
 
-use Content;
-use MediaWiki\Content\Renderer\ContentParseParams;
-use ParserOutput;
 use TextContentHandler;
 
 class LakatContentHandler extends TextContentHandler {
@@ -16,15 +13,11 @@ class LakatContentHandler extends TextContentHandler {
 		return LakatContent::class;
 	}
 
-	protected function fillParserOutput( Content $content, ContentParseParams $cpoParams, ParserOutput &$output ) {
-		if ( $cpoParams->getGenerateHtml() ) {
-			$html = htmlspecialchars( $content->getText() );
-			$html = "This content was transformed for view. Here is the original content: <pre>" . $html . "</pre>";
-		} else {
-			$html = null;
-		}
-
-		$output->clearWrapperDivClass();
-		$output->setText( $html );
+	public function getActionOverrides() {
+		return [
+			'edit' => LakatEditAction::class,
+			'submit' => LakatSubmitAction::class,
+			'view' => LakatViewAction::class,
+		];
 	}
 }

--- a/src/LakatContentHandler.php
+++ b/src/LakatContentHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use Content;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use ParserOutput;
+use TextContentHandler;
+
+class LakatContentHandler extends TextContentHandler {
+	public function __construct() {
+		parent::__construct( LakatContent::MODEL_ID );
+	}
+
+	protected function getContentClass() {
+		return LakatContent::class;
+	}
+
+	protected function fillParserOutput( Content $content, ContentParseParams $cpoParams, ParserOutput &$output ) {
+		if ( $cpoParams->getGenerateHtml() ) {
+			$html = htmlspecialchars( $content->getText() );
+			$html = "This content was transformed for view. Here is the original content: <pre>" . $html . "</pre>";
+		} else {
+			$html = null;
+		}
+
+		$output->clearWrapperDivClass();
+		$output->setText( $html );
+	}
+}

--- a/src/LakatEditAction.php
+++ b/src/LakatEditAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use EditAction;
+use MediaWiki\MainConfigNames;
+
+class LakatEditAction extends EditAction {
+	/**
+	 * This method is the same as EditAction::show() except EditPage is replaced with customized LakatEditPage.
+	 */
+	public function show() {
+		$this->useTransactionalTimeLimit();
+
+		$out = $this->getOutput();
+		$out->setRobotPolicy( 'noindex,nofollow' );
+
+		$out->disableClientCache();
+
+		if ( $this->getContext()->getConfig()->get( MainConfigNames::UseMediaWikiUIEverywhere ) ) {
+			$out->addModuleStyles( [
+				'mediawiki.ui.input',
+				'mediawiki.ui.checkbox',
+			] );
+		}
+
+		$article = $this->getArticle();
+		if ( $this->getHookRunner()->onCustomEditor( $article, $this->getUser() ) ) {
+			$editor = new LakatEditPage( $article );	// use custom edit page form
+			$editor->setContextTitle( $this->getTitle() );
+			$editor->edit();
+		}
+	}
+}

--- a/src/LakatEditPage.php
+++ b/src/LakatEditPage.php
@@ -7,37 +7,17 @@ use MediaWiki\EditPage\EditPage;
 class LakatEditPage extends EditPage {
 	protected function showContentForm() {
 		// load actual content for edit from lakat storage
-		$this->textbox1 = $this->loadBranch();
+		$this->textbox1 = LakatStorage::getInstance()->loadBranch($this->getTitle()->getId());
 
 		parent::showContentForm();
 	}
 
 	protected function importContentFormData( &$request ) {
-		$this->saveBranch();
+		LakatStorage::getInstance()->saveBranch($this->getTitle()->getId(), $this->textbox1);
+
 		// we saved content in lakat storage,
 		// so now we can save nothing in mediawiki storage
 		return '';
 	}
 
-	/**
-	 * This is stub for lakat storage
-	 */
-	private function saveBranch()
-	{
-		file_put_contents($this->getPageDataFilename(), $this->textbox1);
-	}
-
-	private function loadBranch()
-	{
-		$filename = $this->getPageDataFilename();
-		if (!file_exists($filename)) {
-			return '';
-		}
-		return file_get_contents($filename);
-	}
-
-	private function getPageDataFilename(): string
-	{
-		return MW_INSTALL_PATH . '/cache/page_' . $this->getTitle()->getId() . '.txt';
-	}
 }

--- a/src/LakatEditPage.php
+++ b/src/LakatEditPage.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use MediaWiki\EditPage\EditPage;
+
+class LakatEditPage extends EditPage {
+	protected function showContentForm() {
+		// load actual content for edit from lakat storage
+		$this->textbox1 = $this->loadBranch();
+
+		parent::showContentForm();
+	}
+
+	protected function importContentFormData( &$request ) {
+		$this->saveBranch();
+		// we saved content in lakat storage,
+		// so now we can save nothing in mediawiki storage
+		return '';
+	}
+
+	/**
+	 * This is stub for lakat storage
+	 */
+	private function saveBranch()
+	{
+		file_put_contents($this->getPageDataFilename(), $this->textbox1);
+	}
+
+	private function loadBranch()
+	{
+		$filename = $this->getPageDataFilename();
+		if (!file_exists($filename)) {
+			return '';
+		}
+		return file_get_contents($filename);
+	}
+
+	private function getPageDataFilename(): string
+	{
+		return MW_INSTALL_PATH . '/cache/page_' . $this->getTitle()->getId() . '.txt';
+	}
+}

--- a/src/LakatStorage.php
+++ b/src/LakatStorage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+/**
+ * This is stub for lakat storage
+ */
+class LakatStorage {
+	private static LakatStorage $instance;
+
+	public static function getInstance(): LakatStorage {
+		 if (!isset(self::$instance)) {
+			 self::$instance = new self;
+		 }
+		 return self::$instance;
+	}
+
+	public function saveBranch(string $id, string $text)
+	{
+		file_put_contents($this->getPageDataFilename($id), $text);
+	}
+
+	public function loadBranch(string $id)
+	{
+		$filename = $this->getPageDataFilename($id);
+		if (!file_exists($filename)) {
+			return '';
+		}
+		return file_get_contents($filename);
+	}
+
+	public function getPageDataFilename(string $id): string
+	{
+		return MW_INSTALL_PATH . '/cache/page_' . $id . '.txt';
+	}
+}

--- a/src/LakatSubmitAction.php
+++ b/src/LakatSubmitAction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use MediaWiki\Session\SessionManager;
+
+class LakatSubmitAction extends LakatEditAction {
+	public function getName() {
+		return 'submit';
+	}
+
+	/**
+	 * @see \SubmitAction::show()
+	 */
+	public function show() {
+		// Send a cookie so anons get talk message notifications
+		SessionManager::getGlobalSession()->persist();
+
+		parent::show();
+	}
+}

--- a/src/LakatViewAction.php
+++ b/src/LakatViewAction.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MediaWiki\Extension\Lakat;
+
+use ViewAction;
+
+class LakatViewAction extends ViewAction {
+	/**
+	 * Here we replace content of the page with content fetched from lakat storage
+	 */
+	public function show() {
+		parent::show();
+
+		$this->getOutput()->clearHTML();
+		$text = $this->loadBranch();
+		$this->getOutput()->addWikiTextAsContent($text);
+
+	}
+
+	/**
+	 * This is stub for lakat storage
+	 */
+	private function loadBranch()
+	{
+		$filename = $this->getPageDataFilename();
+		if (!file_exists($filename)) {
+			return '';
+		}
+		return file_get_contents($filename);
+	}
+
+	private function getPageDataFilename(): string
+	{
+		return MW_INSTALL_PATH . '/cache/page_' . $this->getTitle()->getId() . '.txt';
+	}
+}

--- a/src/LakatViewAction.php
+++ b/src/LakatViewAction.php
@@ -12,25 +12,9 @@ class LakatViewAction extends ViewAction {
 		parent::show();
 
 		$this->getOutput()->clearHTML();
-		$text = $this->loadBranch();
+
+		$text = LakatStorage::getInstance()->loadBranch($this->getTitle()->getId());
 		$this->getOutput()->addWikiTextAsContent($text);
 
-	}
-
-	/**
-	 * This is stub for lakat storage
-	 */
-	private function loadBranch()
-	{
-		$filename = $this->getPageDataFilename();
-		if (!file_exists($filename)) {
-			return '';
-		}
-		return file_get_contents($filename);
-	}
-
-	private function getPageDataFilename(): string
-	{
-		return MW_INSTALL_PATH . '/cache/page_' . $this->getTitle()->getId() . '.txt';
 	}
 }

--- a/src/SpecialCreateBranch.php
+++ b/src/SpecialCreateBranch.php
@@ -72,7 +72,7 @@ class SpecialCreateBranch extends FormSpecialPage
 		}
 
 		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
-		$text = ContentHandler::makeContent( $wikitext, null, CONTENT_MODEL_WIKITEXT);
+		$text = ContentHandler::makeContent( $wikitext, null, LakatContent::MODEL_ID);
 		$comment = CommentStoreComment::newUnsavedComment(
 			wfMessage( 'createbranch-revision-comment' )->inContentLanguage()->text()
 		);


### PR DESCRIPTION
In this PR:
* added dedicated content model for Lakat content
* the new content model intercepts page edits and views and replaces content with stored separately
* in wiki storage empty content is saved

Page sections are not subject of this PR.

Mediawiki storage is still active in this implementation, and Lakat storage can work in parallel. Here I need to understand the goal better: do we need to store anything in mediawiki storage or maybe empty content stored in mediawiki is desirable? I'm nor sure if it is possible to fully turn off mediawiki revision storage and if we need wiki data model.

Anyway, I think this PR is a good starting point for grounded discussion on how we want to merge Lakat data model with Mediawiki data model.